### PR TITLE
add to deposit tx

### DIFF
--- a/src/account/account.ts
+++ b/src/account/account.ts
@@ -117,7 +117,7 @@ export class Account extends BaseContract {
         }]
       }, {
         blocksBehind: 3,
-        expireSeconds: 30,
+        expireSeconds: this.config.eosTxExpire,
       });
     } catch (err) {
       throw new Error(err)

--- a/src/base-contract/baseContract.ts
+++ b/src/base-contract/baseContract.ts
@@ -299,7 +299,7 @@ export class BaseContract {
         actions
       }, {
         blocksBehind: 3,
-        expireSeconds: 30,
+        expireSeconds: this.config.eosTxExpire,
       }).catch((err)=>{
         return Promise.reject(err)
       });

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -55,7 +55,8 @@ export const defaultConfiguration = (environment: string = 'testnet', config?: E
             qualifierAccountId:     config?.qualifierAccountId     ?? 127,
             eosQualifierContract:   config?.eosQualifierContract   ?? 'efxqualifier',
             validationUrl:          config?.validationUrl          ?? 'https://validation-bot-mainnet-t4o43.ondigitalocean.app/',
-            ipfsCache:              config?.ipfsCache              ?? true
+            ipfsCache:              config?.ipfsCache              ?? true,
+            eosTxExpire:        120
         }
 
     } else if (environment === 'jungle' || environment === 'jungle3' || environment === 'testnet') {
@@ -98,7 +99,8 @@ export const defaultConfiguration = (environment: string = 'testnet', config?: E
             qualifierAccountId:     config?.qualifierAccountId     ?? 389,
             eosQualifierContract:   config?.eosQualifierContract   ?? 'efxdavid1bot',
             validationUrl:          config?.validationUrl          ?? 'https://validation-bot-jungle-mlolk.ondigitalocean.app',
-            ipfsCache:              config?.ipfsCache              ?? true
+            ipfsCache:              config?.ipfsCache              ?? true,
+            eosTxExpire:        120
         }
 
     } else if (environment === 'local') {
@@ -146,7 +148,8 @@ export const defaultConfiguration = (environment: string = 'testnet', config?: E
             qualifierAccountId:     config?.qualifierAccountId     ?? 389,
             eosQualifierContract:   config?.eosQualifierContract   ?? 'efxdavid1bot',
             validationUrl:          config?.validationUrl          ?? 'https://validation-bot-jungle-mlolk.ondigitalocean.app',
-            ipfsCache:              config?.ipfsCache              ?? true
+            ipfsCache:              config?.ipfsCache              ?? true,
+            eosTxExpire:        120
         }
 
     } else {

--- a/src/types/effectClientConfig.ts
+++ b/src/types/effectClientConfig.ts
@@ -255,4 +255,10 @@ export interface EffectClientConfig {
    * Cache ipfs requests
    */
   ipfsCache ? : boolean
+
+  /**
+   * Eos transaction expire time in seconds
+   * The amount of time required by the user to sign the transaction.
+   */
+   eosTxExpire ? : number
 }


### PR DESCRIPTION
Transction were expiring too quickly when signing an eos transaction.
This PR will adds a configuration property where the txExpiration time can be set. 
And it is used in the places where the transaction is signed and sent to the eos network. 