### PR TITLE
Account for network fees in publish batch

### DIFF
--- a/src/force/force.ts
+++ b/src/force/force.ts
@@ -458,9 +458,12 @@ export class Force extends BaseContract {
       sig = await this.generateSignature(serialbuff)
     }
 
+    // TODO: get the fee_percentage from the force settings table
     const campaign = await this.getCampaign(campaignId)
     const [reward, symbol] = parseAsset(campaign.reward.quantity)
-    const batchPrice = reward * content.tasks.length * repetitions
+    const feePercentage = 0.1;
+    const batchPrice = (reward + reward * feePercentage) * content.tasks.length * repetitions
+
 
     // TODO: below code copied from vaccount module, can we just call that code?
     let vaccSig: Signature;


### PR DESCRIPTION
The new network fees will require dApps to deposit the fee amount to a batch before they can publish.

These changes assume a fixed fee of 10%, but should later be retrieved from the `settings.fee_percentage` field in the force account. 